### PR TITLE
Hotfix: Move default property to POST body only

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -280,7 +280,9 @@ definitions:
               creatorId:
                 $ref: '#/definitions/creatorId'
               permissions:
-                $ref: '#/definitions/permissions'
+                allOf:
+                - default: 'advisor'
+                - $ref: '#/definitions/permissions'
               context:
                 $ref: '#/definitions/context'
             required:
@@ -362,7 +364,6 @@ definitions:
       - 'advisor'
       - 'advisors'
       - 'student'
-    default: 'advisor'
     description: "A string that defines the permissions of who can view the note. 'advisor' indicates that only
       the advisor who created the note may view it. 'advisors' indicates that all advisors can view the note.
       'student' indicates that all advisors as well as the student who the note is on may view the note."


### PR DESCRIPTION
There was a bug where a PATCH request without a value for `permissions` would cause the value to be set to its default. This is fixed by only having the POST body have a default value for this property.